### PR TITLE
webmin-setup-repos.sh filename change

### DIFF
--- a/content/download.md
+++ b/content/download.md
@@ -8,11 +8,11 @@ showtoc: true
 ## Repository
 
 ### Setup
-The simplest and best way to get [**Webmin**](/about/) is to use automatic [**`webmin-setup-repos.sh`**](https://github.com/webmin/webmin/blob/master/webmin-setup-repos.sh) script to configure repositories on your **RHEL** or **Debian** derivative systems. It can be done in two easy steps:
+The simplest and best way to get [**Webmin**](/about/) is to use automatic [**`webmin-setup-repo.sh`**](https://github.com/webmin/webmin/blob/master/webmin-setup-repo.sh) script to configure repositories on your **RHEL** or **Debian** derivative systems. It can be done in two easy steps:
 
 ```
-curl -o webmin-setup-repos.sh https://raw.githubusercontent.com/webmin/webmin/master/webmin-setup-repos.sh
-sh webmin-setup-repos.sh
+curl -o webmin-setup-repo.sh https://raw.githubusercontent.com/webmin/webmin/master/webmin-setup-repo.sh
+sh webmin-setup-repo.sh
 ```
 
 This script will automatically setup our repository and install our GPG keys on your system, and provide **`webmin`** package for installation and easy upgrades in the future. The supported and tested systems are **Red Hat Enterprise Linux**, **Alma**, **Rocky**, **Oracle**, **CentOS Stream**, **Fedora** or **Debian**, **Ubuntu**, **Kali**.


### PR DESCRIPTION
The repo setup filename got changed to `webmin-setup-repo.sh` from `webmin-setup-repos.sh`. The readme should include the correct raw URL.

Works with CURL: `https://raw.githubusercontent.com/webmin/webmin/master/webmin-setup-repo.sh`

Does not work with CURL: `https://raw.githubusercontent.com/webmin/webmin/master/webmin-setup-repos.sh`