### PR TITLE
Change: Fix typo on squid cachemgr.cgi bug

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -8,7 +8,7 @@ This page lists security problems found in Webmin and Usermin, versions affected
 
 {{< alert warning question "Found a bug?" "If you info found a new security related bug report it at **[security@webmin.com](mailto:security@webmin.com)**" >}}
 
-### Webmin 2.600 and below
+### Webmin prior to 2.600
 #### Privilige escalation using Squid module [CVE-2025-67738]
 
 - If an untrusted Webmin user is granted access to the Squid module and the


### PR DESCRIPTION
It seems this got fixed in / via webmin/webmin@1a52bf4d72f9da6d79250c66e51f41c6f5b880ee which seems to have been already included in 2.600 as seen here:

https://github.com/webmin/webmin/blob/2.600/squid/cachemgr.cgi

This can be cross-checked that 2.610 didn't received any additional fixes / commit on this file:

https://github.com/webmin/webmin/blob/2.610/squid/cachemgr.cgi