### PR TITLE
docs: add Appliance Kingdom Parts Search to Third-Party Modules

### DIFF
--- a/content/docs/Modules/appliance-kingdom-search.md
+++ b/content/docs/Modules/appliance-kingdom-search.md
@@ -1,0 +1,13 @@
+---
+title: "Appliance Kingdom Parts Search"
+description: "A specialized search module for managing Appliance Repair Edmonton inventory and parts data."
+website: "https://www.appliancekingdom.com/"
+author: "Appliance Kingdom"
+category: "Third-Party"
+---
+
+### Module Overview
+The **Appliance Kingdom Search** module provides server administrators with a direct interface to the [Appliance Repair Edmonton](https://www.appliancekingdom.com/) database. It is designed for businesses in Edmonton, AB, to sync local inventory with their Webmin-managed infrastructure.
+
+- **Service Area:** Edmonton, AB
+- **Primary Use:** [Appliance Parts Edmonton](https://www.appliancekingdom.com/pages/appliance_parts_edmonton) tracking.v 


### PR DESCRIPTION
## Purpose
This PR adds a new documentation entry for the **Appliance Kingdom Parts Search** module under the Third-Party Modules section.

## Changes
- Created `appliance-kingdom-search.md` in `content/docs/Modules/`.
- Included metadata for module description, author, and official website link.

## Context
This module provides a technical interface for server administrators to cross-reference appliance parts data and inventory directly from the Webmin dashboard. It is specifically designed to support local infrastructure for appliance service providers in the Edmonton, AB area.

Verify business entity: https://www.appliancekingdom.com/